### PR TITLE
Add final post-processing pass

### DIFF
--- a/Core/RenderingPipeline/RenderGraph/BlurOutlineRenderGraph.cpp
+++ b/Core/RenderingPipeline/RenderGraph/BlurOutlineRenderGraph.cpp
@@ -11,6 +11,7 @@
 #include "Core/RenderingPipeline/RenderingManager/Pass/ShadowMapPass.h"
 #include "Core/RenderingPipeline/RenderingManager/Pass/SkyboxPass.h"
 #include "Core/RenderingPipeline/RenderingManager/Pass/VerticalBlurPass.h"
+#include "Core/RenderingPipeline/RenderingManager/Pass/FinalPostProcessPass.h"
 #include "Core/RenderingPipeline/RenderGraph/BlurOutlineRenderingPass.h"
 #include "Core/RenderingPipeline/RenderTarget.h"
 
@@ -114,15 +115,24 @@ namespace RenderGraphNameSpace
 			AddRenderPass(std::move(pass));
 		}
 
-		{
-			auto pass = std::make_unique<CameraWireFramePass>("wireframe");
-			pass->SetSinkLinkage("renderTarget", "vertical.renderTarget");
-			pass->SetSinkLinkage("depthStencil", "vertical.depthStencil");
+               {
+                        auto pass = std::make_unique<CameraWireFramePass>("wireframe");
+                        pass->SetSinkLinkage("renderTarget", "vertical.renderTarget");
+                        pass->SetSinkLinkage("depthStencil", "vertical.depthStencil");
 
-			AddRenderPass(std::move(pass));
-		}
+                        AddRenderPass(std::move(pass));
+                }
 
-		SetSinkTarget("backbuffer", "wireframe.renderTarget");
+               {
+                        auto pass = std::make_unique<FinalPostProcessPass>("postprocess", Window::GetDxGraphic().GetWidth(), Window::GetDxGraphic().GetHeight());
+                        pass->SetSinkLinkage("renderTargetIn", "wireframe.renderTargetRender");
+                        pass->SetSinkLinkage("kernel", "$.blurKernel");
+                        pass->SetSinkLinkage("direction", "$.blurDirection");
+
+                        AddRenderPass(std::move(pass));
+                }
+
+                SetSinkTarget("backbuffer", "postprocess.renderTargetOut");
 
 		Finalize();
 	}

--- a/Core/RenderingPipeline/RenderingManager/Pass/CameraWireFramePass.h
+++ b/Core/RenderingPipeline/RenderingManager/Pass/CameraWireFramePass.h
@@ -20,7 +20,8 @@ namespace RenderGraphNameSpace
 
 			AddDataConsumer(DirectBufferDataConsumer<RenderTarget>::Create("renderTarget", renderTarget));
 			AddDataConsumer(DirectBufferDataConsumer<DepthStencil>::Create("depthStencil", depthStencil));
-			AddDataProvider(DirectBufferPipelineDataProvider<RenderTarget>::Create("renderTarget", renderTarget));
+                       AddDataProvider(DirectBufferPipelineDataProvider<RenderTarget>::Create("renderTarget", renderTarget));
+                       AddDataProvider(DirectRenderPipelineDataProvider<RenderTarget>::Create("renderTargetRender", renderTarget));
 			AddDataProvider(DirectBufferPipelineDataProvider<DepthStencil>::Create("depthStencil", depthStencil));
 
 			AddRender(Stencil::GetRender(Stencil::DrawMode::DepthReversed));

--- a/Core/RenderingPipeline/RenderingManager/Pass/FinalPostProcessPass.cpp
+++ b/Core/RenderingPipeline/RenderingManager/Pass/FinalPostProcessPass.cpp
@@ -1,0 +1,38 @@
+#include "stdafx.h"
+#include "FinalPostProcessPass.h"
+
+#include "Core/RenderingPipeline/RenderGraph/PipelineDataConsumer.h"
+#include "Core/RenderingPipeline/RenderGraph/PipelineDataProvider.h"
+#include "Core/RenderingPipeline/Pipeline/VSPS/PixelShader.h"
+#include "Core/RenderingPipeline/Pipeline/OM/ColorBlend.h"
+#include "Core/RenderingPipeline/Pipeline/VSPS/SamplerState.h"
+
+using namespace Graphic;
+
+namespace RenderGraphNameSpace
+{
+    FinalPostProcessPass::FinalPostProcessPass(std::string name, unsigned int width, unsigned int height)
+        : PostProcessFullScreenRenderPass(std::move(name))
+    {
+        AddRender(PixelShader::GetRender("Shader/PostProcessing/ScreenBlur.hlsl"));
+        AddRender(ColorBlend::GetRender(false));
+        AddRender(SamplerState::GetRender(SamplerState::TextureFilter::Point));
+
+        AddRenderSink<RenderTarget>("renderTargetIn");
+        AddRenderSink<CachingPixelConstantBufferEx>("kernel");
+        AddDataConsumer(DirectRenderPipelineDataConsumer<CachingPixelConstantBufferEx>::Create("direction", direction));
+
+        renderTarget = std::make_shared<ShaderInputRenderTarget>(width, height, 0u);
+        AddDataProvider(DirectBufferPipelineDataProvider<RenderTarget>::Create("renderTargetOut", renderTarget));
+    }
+
+    void FinalPostProcessPass::Execute() NOEXCEPTRELEASE
+    {
+        auto buffer = direction->GetBuffer();
+        buffer["isHorizontal"] = false;
+        direction->SetBuffer(buffer);
+        direction->SetRenderPipeline();
+
+        PostProcessFullScreenRenderPass::Execute();
+    }
+}

--- a/Core/RenderingPipeline/RenderingManager/Pass/FinalPostProcessPass.h
+++ b/Core/RenderingPipeline/RenderingManager/Pass/FinalPostProcessPass.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "PostProcessFullScreenRenderPass.h"
+#include "Core/RenderingPipeline/Pipeline/VSPS/ConstantBufferEx.h"
+
+namespace Graphic { class RenderTarget; }
+
+namespace RenderGraphNameSpace
+{
+    class FinalPostProcessPass : public PostProcessFullScreenRenderPass
+    {
+    public:
+        FinalPostProcessPass(std::string name, unsigned int width, unsigned int height);
+        void Execute() NOEXCEPTRELEASE override;
+
+    private:
+        std::shared_ptr<Graphic::CachingPixelConstantBufferEx> direction;
+    };
+}


### PR DESCRIPTION
## Summary
- introduce `FinalPostProcessPass` derived from `PostProcessFullScreenRenderPass`
- apply the new pass at the end of `BlurOutlineRenderGraph`
- fix provider type to supply the postprocess render target as a buffer
- expose `CameraWireFramePass`'s render target through a render provider for the final postprocess
- fix wireframe output provider

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6856e085041883288b722269f060bde3