### PR TITLE
Add screen blur post-processing passes

### DIFF
--- a/Core/RenderingPipeline/RenderGraph/BlurOutlineRenderGraph.cpp
+++ b/Core/RenderingPipeline/RenderGraph/BlurOutlineRenderGraph.cpp
@@ -12,6 +12,8 @@
 #include "Core/RenderingPipeline/RenderingManager/Pass/ShadowMapPass.h"
 #include "Core/RenderingPipeline/RenderingManager/Pass/SkyboxPass.h"
 #include "Core/RenderingPipeline/RenderingManager/Pass/VerticalBlurPass.h"
+#include "Core/RenderingPipeline/RenderingManager/Pass/ScreenHorizontalBlurPass.h"
+#include "Core/RenderingPipeline/RenderingManager/Pass/ScreenVerticalBlurPass.h"
 #include "Core/RenderingPipeline/RenderGraph/BlurOutlineRenderingPass.h"
 #include "Core/RenderingPipeline/RenderTarget.h"
 
@@ -151,8 +153,29 @@ namespace RenderGraphNameSpace
             AddRenderPass(std::move(pass));
         }
 
+        // 12단계: 전체 화면 수평 블러 패스
+        {
+            auto pass = std::make_unique<ScreenHorizontalBlurPass>("postHorizontal", Window::GetDxGraphic().GetWidth(), Window::GetDxGraphic().GetHeight());
+            pass->SetConsumerLinkage("scratchIn", "wireframe.renderTarget");
+            pass->SetConsumerLinkage("kernel", "$.blurKernel");
+            pass->SetConsumerLinkage("direction", "$.blurDirection");
+
+            AddRenderPass(std::move(pass));
+        }
+
+        // 13단계: 전체 화면 수직 블러 패스
+        {
+            auto pass = std::make_unique<ScreenVerticalBlurPass>("postVertical");
+            pass->SetConsumerLinkage("scratchIn", "postHorizontal.scratchOut");
+            pass->SetConsumerLinkage("kernel", "$.blurKernel");
+            pass->SetConsumerLinkage("direction", "$.blurDirection");
+            pass->SetConsumerLinkage("renderTarget", "$.backbuffer");
+
+            AddRenderPass(std::move(pass));
+        }
+
         // 최종 출력을 백버퍼로 설정
-        SetGlobalConsumerTarget("backbuffer", "wireframe.renderTarget");
+        SetGlobalConsumerTarget("backbuffer", "postVertical.renderTarget");
 
         // 렌더 그래프 완료 및 의존성 검증
         Finalize();

--- a/Core/RenderingPipeline/RenderGraph/BlurOutlineRenderGraph.h
+++ b/Core/RenderingPipeline/RenderGraph/BlurOutlineRenderGraph.h
@@ -2,6 +2,8 @@
 
 #include "RenderGraph.h"
 #include "Core/RenderingPipeline/Pipeline/VSPS/ConstantBufferEx.h"
+#include "Core/RenderingPipeline/RenderingManager/Pass/ScreenHorizontalBlurPass.h"
+#include "Core/RenderingPipeline/RenderingManager/Pass/ScreenVerticalBlurPass.h"
 
 #include <memory>
 

--- a/Core/RenderingPipeline/RenderingManager/Pass/ScreenHorizontalBlurPass.cpp
+++ b/Core/RenderingPipeline/RenderingManager/Pass/ScreenHorizontalBlurPass.cpp
@@ -1,0 +1,51 @@
+#include "stdafx.h"
+#include "ScreenHorizontalBlurPass.h"
+
+#include "Core/RenderingPipeline/Pipeline/OM/ColorBlend.h"
+#include "Core/RenderingPipeline/Pipeline/VSPS/ConstantBufferEx.h"
+#include "Core/RenderingPipeline/Pipeline/VSPS/PixelShader.h"
+#include "Core/RenderingPipeline/Pipeline/VSPS/SamplerState.h"
+#include "Core/RenderingPipeline/RenderGraph/PipelineDataConsumer.h"
+#include "Core/RenderingPipeline/RenderGraph/PipelineDataProvider.h"
+#include "Core/RenderingPipeline/RenderTarget.h"
+#include "Core/Exception/RenderGraphCompileException.h"
+
+#include <sstream>
+
+using namespace Graphic;
+
+namespace RenderGraphNameSpace
+{
+    ScreenHorizontalBlurPass::ScreenHorizontalBlurPass(std::string name, unsigned int width, unsigned int height)
+        : PostProcessFullScreenRenderPass(std::move(name))
+    {
+        if (width == 0 || height == 0)
+        {
+            std::ostringstream oss;
+            oss << "스크린 수평 블러 패스 생성 오류: 잘못된 해상도입니다.\n"
+                << "입력된 해상도: " << width << " x " << height;
+            throw RENDER_GRAPHIC_EXCEPTION(oss.str());
+        }
+
+        AddRender(PixelShader::GetRender("Shader/PostProcessing/ScreenBlur.hlsl"));
+        AddRender(ColorBlend::GetRender(false));
+        AddRender(SamplerState::GetRender(SamplerState::TextureFilter::Point));
+
+        AddRenderDataConsumer<RenderTarget>("scratchIn");
+        AddRenderDataConsumer<CachingPixelConstantBufferEx>("kernel");
+        AddDataConsumer(DirectRenderPipelineDataConsumer<CachingPixelConstantBufferEx>::Create("direction", direction));
+
+        renderTarget = std::make_shared<ShaderInputRenderTarget>(width / 2, height / 2, 0u);
+        AddDataProvider(DirectRenderPipelineDataProvider<RenderTarget>::Create("scratchOut", renderTarget));
+    }
+
+    void ScreenHorizontalBlurPass::Execute() NOEXCEPTRELEASE
+    {
+        auto buffer = direction->GetBuffer();
+        buffer["isHorizontal"] = true;
+        direction->SetBuffer(buffer);
+        direction->SetRenderPipeline();
+
+        PostProcessFullScreenRenderPass::Execute();
+    }
+}

--- a/Core/RenderingPipeline/RenderingManager/Pass/ScreenHorizontalBlurPass.h
+++ b/Core/RenderingPipeline/RenderingManager/Pass/ScreenHorizontalBlurPass.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "PostProcessFullScreenRenderPass.h"
+#include "Core/RenderingPipeline/Pipeline/VSPS/ConstantBufferEx.h"
+
+class DxGraphic;
+
+namespace Graphic
+{
+    class PixelShader;
+    class RenderTarget;
+}
+
+namespace RenderGraphNameSpace
+{
+    // 전체 화면 수평 블러를 적용하는 패스
+    class ScreenHorizontalBlurPass : public PostProcessFullScreenRenderPass
+    {
+    public:
+        ScreenHorizontalBlurPass(std::string name, unsigned int width, unsigned int height);
+        void Execute() NOEXCEPTRELEASE override;
+
+    private:
+        std::shared_ptr<Graphic::CachingPixelConstantBufferEx> direction;
+    };
+}

--- a/Core/RenderingPipeline/RenderingManager/Pass/ScreenVerticalBlurPass.cpp
+++ b/Core/RenderingPipeline/RenderingManager/Pass/ScreenVerticalBlurPass.cpp
@@ -1,0 +1,38 @@
+#include "stdafx.h"
+#include "ScreenVerticalBlurPass.h"
+
+#include "Core/RenderingPipeline/RenderGraph/PipelineDataConsumer.h"
+#include "Core/RenderingPipeline/RenderGraph/PipelineDataProvider.h"
+#include "Core/RenderingPipeline/Pipeline/VSPS/PixelShader.h"
+#include "Core/RenderingPipeline/Pipeline/OM/ColorBlend.h"
+#include "Core/RenderingPipeline/Pipeline/VSPS/SamplerState.h"
+
+using namespace Graphic;
+
+namespace RenderGraphNameSpace
+{
+    ScreenVerticalBlurPass::ScreenVerticalBlurPass(std::string name)
+        : PostProcessFullScreenRenderPass(std::move(name))
+    {
+        AddRender(PixelShader::GetRender("Shader/PostProcessing/ScreenBlur.hlsl"));
+        AddRender(ColorBlend::GetRender(false));
+        AddRender(SamplerState::GetRender(SamplerState::TextureFilter::Point));
+
+        AddRenderDataConsumer<RenderTarget>("scratchIn");
+        AddRenderDataConsumer<CachingPixelConstantBufferEx>("kernel");
+        AddDataConsumer(DirectRenderPipelineDataConsumer<CachingPixelConstantBufferEx>::Create("direction", direction));
+        AddDataConsumer(DirectBufferDataConsumer<RenderTarget>::Create("renderTarget", renderTarget));
+
+        AddDataProvider(DirectBufferPipelineDataProvider<RenderTarget>::Create("renderTarget", renderTarget));
+    }
+
+    void ScreenVerticalBlurPass::Execute() NOEXCEPTRELEASE
+    {
+        auto buffer = direction->GetBuffer();
+        buffer["isHorizontal"] = false;
+        direction->SetBuffer(buffer);
+        direction->SetRenderPipeline();
+
+        PostProcessFullScreenRenderPass::Execute();
+    }
+}

--- a/Core/RenderingPipeline/RenderingManager/Pass/ScreenVerticalBlurPass.h
+++ b/Core/RenderingPipeline/RenderingManager/Pass/ScreenVerticalBlurPass.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "PostProcessFullScreenRenderPass.h"
+#include "Core/RenderingPipeline/Pipeline/VSPS/ConstantBufferEx.h"
+
+class DxGraphic;
+
+namespace Graphic
+{
+    class PixelShader;
+    class RenderTarget;
+}
+
+namespace RenderGraphNameSpace
+{
+    // 전체 화면 수직 블러를 적용하는 패스
+    class ScreenVerticalBlurPass : public PostProcessFullScreenRenderPass
+    {
+    public:
+        ScreenVerticalBlurPass(std::string name);
+        void Execute() NOEXCEPTRELEASE override;
+
+    private:
+        std::shared_ptr<Graphic::CachingPixelConstantBufferEx> direction;
+    };
+}


### PR DESCRIPTION
## Summary
- add screen blur horizontal/vertical passes for full-screen effects
- include new passes in blur outline render graph
- wire new passes to output backbuffer

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6856ee54f7988328832d95f2490cd657